### PR TITLE
Clean the namespaces up a bit

### DIFF
--- a/Rabbit.Auth/ArmorGames.cs
+++ b/Rabbit.Auth/ArmorGames.cs
@@ -7,7 +7,7 @@
 using System;
 using PlayerIOClient;
 
-namespace Rabbit.Rabbit.Auth
+namespace Rabbit.Auth
 {
     /// <summary>
     ///     ArmorGames authentication class.

--- a/Rabbit.Auth/AuthType.cs
+++ b/Rabbit.Auth/AuthType.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Rabbit.Auth
+{
+    enum AuthType
+    {
+        Regular = 0,
+        Facebook,
+        Kongregate,
+        ArmorGames
+    }
+}

--- a/Rabbit.Auth/Facebook.cs
+++ b/Rabbit.Auth/Facebook.cs
@@ -1,6 +1,6 @@
 using PlayerIOClient;
 
-namespace Rabbit.Rabbit.Auth
+namespace Rabbit.Auth
 {
     public static class Facebook
     {

--- a/Rabbit.Auth/Kongregate.cs
+++ b/Rabbit.Auth/Kongregate.cs
@@ -1,6 +1,6 @@
 using PlayerIOClient;
 
-namespace Rabbit.Rabbit.Auth
+namespace Rabbit.Auth
 {
     public static class Kongregate
     {

--- a/Rabbit.Core/Rabbit.Core.cs
+++ b/Rabbit.Core/Rabbit.Core.cs
@@ -1,6 +1,0 @@
-﻿namespace Rabbit.Rabbit.Core
-{
-    public class Core
-    {
-    }
-}

--- a/Rabbit.cs
+++ b/Rabbit.cs
@@ -7,14 +7,14 @@
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using PlayerIOClient;
-using Rabbit.Rabbit.Auth;
+using Rabbit.Auth;
 
 namespace Rabbit
 {
     /// <summary>
     ///     Authentication core.
     /// </summary>
-    public class Auth
+    public class Rabbit
     {
         /// <summary>
         ///     Gets the Client for the main authentication system.
@@ -42,7 +42,7 @@ namespace Rabbit
 
             email = Regex.Replace(email, @"\s+", "");
 
-            string accountType = "regular";
+            AuthType authType = AuthType.Regular;
 
             if (string.IsNullOrEmpty(password) &&
                 email.Length > 100 &&
@@ -50,7 +50,7 @@ namespace Rabbit
             {
                 // Facebook login if "password" is over 100 characters, contains only A-Z,a-z and 0-9 and yeah.
                 // there is no email supplied (null)
-                accountType = "facebook";
+                authType = AuthType.Facebook;
             }
 
             if (password != null && (Regex.IsMatch(email, @"^\d+$") &&
@@ -61,7 +61,7 @@ namespace Rabbit
                 // token thing is 64 characeters in hex
                 // and all of the letters are lowercase
                 // then it's Kongregate
-                accountType = "kongregate";
+                authType = AuthType.Kongregate;
             }
 
             // 32 (length) in hex for both user id and auth token
@@ -72,22 +72,22 @@ namespace Rabbit
                                      password.Length == 32 &&
                                      email.Length == 32))
             {
-                accountType = "ArmourGames";
+                authType = AuthType.ArmorGames;
             }
 
-            switch (accountType)
+            switch (authType)
             {
-                case "facebook":
+                case AuthType.Facebook:
                 {
                     Client = Facebook.Authenticate(password);
                     break;
                 }
-                case "kongregate":
+                case AuthType.Kongregate:
                 {
                     Client = Kongregate.Authenticate(email, password);
                     break;
                 }
-                case "ArmourGames":
+                case AuthType.ArmorGames:
                 {
                     Client = ArmorGames.Authenticate(email, password);
                     break;

--- a/Rabbit.csproj
+++ b/Rabbit.csproj
@@ -46,11 +46,11 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Rabbit.Auth.cs" />
-    <Compile Include="Rabbit.Auth\Rabbit.Auth.ArmorGames.cs" />
-    <Compile Include="Rabbit.Auth\Rabbit.Auth.Facebook.cs" />
-    <Compile Include="Rabbit.Auth\Rabbit.Auth.Kongregate.cs" />
-    <Compile Include="Rabbit.Core\Rabbit.Core.cs" />
+    <Compile Include="Rabbit.Auth\AuthType.cs" />
+    <Compile Include="Rabbit.cs" />
+    <Compile Include="Rabbit.Auth\ArmorGames.cs" />
+    <Compile Include="Rabbit.Auth\Facebook.cs" />
+    <Compile Include="Rabbit.Auth\Kongregate.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 


### PR DESCRIPTION
Cleaned the filenames of the auth classes and renamed Rabbit.Auth class to Rabbit.Rabbit to avoid collisions with the namespace.

Added AuthType enum so we don't use a string to store the auth type.
